### PR TITLE
Add linux-x64-musl, linux-arm-libc, linux-arm-musl builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,13 +62,15 @@ jobs:
       - run: find prebuilds
       - uses: actions/upload-artifact@v3
         with:
-          name: prebuild-${{ linux }}-${{ arm64 }}
+          name: prebuild-linux-arm64
           path: ./prebuilds
 
   # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
   publish:
     runs-on: ubuntu-latest
-    needs: [build]
+    #TODO: make sure to re-add build in here too, commented out currently to speed up iteration
+    # needs: [build, cross-compile]
+    needs: [cross-compile]
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,8 +68,8 @@ jobs:
           docker build --platform=linux/arm64 --tag nodegit-linux-musl-arm64 -f scripts/Dockerfile.alpine .
           docker create --platform=linux/arm64 --name nodegit-linux-musl-arm64 nodegit-linux-musl-arm64
           docker cp "nodegit-linux-musl-arm64:/app/prebuilds" .
-      # list what we've got
-      - run: find prebuilds
+      - name: "list the generated files"
+        run: find prebuilds
       - uses: actions/upload-artifact@v4
         with:
           name: prebuild-linux-arm64
@@ -100,13 +100,19 @@ jobs:
       - name: copy libs
         run: |
           set -x
+          mkdir -p prebuilds/linux-arm64
+          mkdir -p prebuilds/linux-x64
+          mkdir -p prebuilds/darwin-arm64
           find ${{ steps.download.outputs.download-path }}
-          mv ${{ steps.download.outputs.download-path }}/*/* ./prebuilds
+          mv ${{ steps.download.outputs.download-path}}prebuild-Linux-X64/linux-x64/* ./prebuilds/linux-x64/
+          mv ${{ steps.download.outputs.download-path}}prebuild-linux-arm64/linux-arm64/* ./prebuilds/linux-arm64/
+          mv ${{ steps.download.outputs.download-path}}prebuild-linux-arm64/linux-x64/* ./prebuilds/linux-x64/
+          mv ${{ steps.download.outputs.download-path}}prebuild-macOS-ARM64/darwin-arm64/* ./prebuilds/darwin-arm64/
           find ./prebuilds
       - name: npm install
         run: npm ci
       - name: publish
         run: |
-          (cat "$NPM_CONFIG_USERCONFIG" || true) && echo "token: ${NODE_AUTH_TOKEN:0:10}" && npm publish --provenance --access public
+          (cat "$NPM_CONFIG_USERCONFIG" || true) && npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
   #           sudo apt-get update && \
   #           sudo apt-get install -y software-properties-common git build-essential clang libssl-dev libkrb5-dev libc++-dev wget python3
   #         npm ci
-  #         npx prebuildify --napi --strip -t "$(node --version | tr -d 'v')"
+  #         npx prebuildify --napi --strip --tag-libc -t "$(node --version | tr -d 'v')"
   #     - uses: actions/upload-artifact@v4
   #       with:
   #         name: prebuild-${{ runner.os }}-${{ runner.arch }}
@@ -53,11 +53,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
-      - name: build linux arm
+      - name: build linux glibc arm
         run: |
-          docker build --platform=linux/arm64 --tag nodegit-linux-arm64 -f scripts/Dockerfile.ubuntu .
-          docker create --platform=linux/arm64 --name nodegit-linux-arm64 nodegit-linux-arm64
-          docker cp "nodegit-linux-arm64:/app/prebuilds" .
+          docker build --platform=linux/arm64 --tag nodegit-linux-glibc-arm64 -f scripts/Dockerfile.debian .
+          docker create --platform=linux/arm64 --name nodegit-linux-glibc-arm64 nodegit-linux-glibc-arm64
+          docker cp "nodegit-linux-glibc-arm64:/app/prebuilds" .
+      - name: build linux musl x64
+        run: |
+          docker build --platform=linux/amd64 --tag nodegit-linux-musl-amd64 -f scripts/Dockerfile.alpine .
+          docker create --platform=linux/amd64 --name nodegit-linux-musl-amd64 nodegit-linux-musl-amd64
+          docker cp "nodegit-linux-musl-amd64:/app/prebuilds" .
+      - name: build linux musl arm
+        run: |
+          docker build --platform=linux/arm64 --tag nodegit-linux-musl-arm64 -f scripts/Dockerfile.alpine .
+          docker create --platform=linux/arm64 --name nodegit-linux-musl-arm64 nodegit-linux-musl-arm64
+          docker cp "nodegit-linux-musl-arm64:/app/prebuilds" .
       # list what we've got
       - run: find prebuilds
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: prebuild-${{ runner.os }}-${{ runner.arch }}
-          path: prebuilds
+          path: ./prebuilds
           retention-days: 14
 
   cross-compile:
@@ -70,10 +70,11 @@ jobs:
           docker cp "nodegit-linux-musl-arm64:/app/prebuilds" .
       # list what we've got
       - run: find prebuilds
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: prebuild-linux-arm64
           path: ./prebuilds
+          retention-days: 14
 
   # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,47 +5,65 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    # TODO: should we run the tests, or can we assume that a v* tag ought to
-    # get published?
-    name: build
-    strategy:
-      matrix:
-        node: [20]
-        os:
-          - name: darwin
-            architecture: arm64
-            host: macos-14
+  # build:
+  #   # TODO: should we run the tests, or can we assume that a v* tag ought to
+  #   # get published?
+  #   name: build
+  #   strategy:
+  #     matrix:
+  #       node: [20]
+  #       os:
+  #         - name: darwin
+  #           architecture: arm64
+  #           host: macos-14
 
-          - name: linux
-            architecture: x86-64
-            host: ubuntu-20.04
-    env:
-      CC: clang
-      CXX: clang++
-      npm_config_clang: 1
-      GYP_DEFINES: use_obsolete_asm=true
-    runs-on: ${{ matrix.os.host }}
+  #         - name: linux
+  #           architecture: x86-64
+  #           host: ubuntu-20.04
+  #   env:
+  #     CC: clang
+  #     CXX: clang++
+  #     npm_config_clang: 1
+  #     GYP_DEFINES: use_obsolete_asm=true
+  #   runs-on: ${{ matrix.os.host }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: true
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20
+  #         check-latest: true
+  #     - name: Prebuildify
+  #       run: |
+  #         [[ $(uname -o) == *Linux ]] && \
+  #           sudo apt-get update && \
+  #           sudo apt-get install -y software-properties-common git build-essential clang libssl-dev libkrb5-dev libc++-dev wget python3
+  #         npm ci
+  #         npx prebuildify --napi --strip -t "$(node --version | tr -d 'v')"
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: prebuild-${{ runner.os }}-${{ runner.arch }}
+  #         path: prebuilds
+  #         retention-days: 14
+
+  cross-compile:
+    name: "cross compile linux/arm"
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          check-latest: true
-      - name: Prebuildify
+      - uses: docker/setup-qemu-action@v3
+      - name: build linux arm
         run: |
-          [[ $(uname -o) == *Linux ]] && \
-            sudo apt-get update && \
-            sudo apt-get install -y software-properties-common git build-essential clang libssl-dev libkrb5-dev libc++-dev wget python3
-          npm ci
-          npx prebuildify --napi --strip -t "$(node --version | tr -d 'v')"
-      - uses: actions/upload-artifact@v4
+          docker build --platform=linux/arm64 --tag nodegit-linux-arm64 -f scripts/Dockerfile.ubuntu .
+          docker create --platform=linux/arm64 --name nodegit-linux-arm64 nodegit-linux-arm64
+          docker cp "nodegit-linux-arm64:/app/prebuilds" .
+      # list what we've got
+      - run: find prebuilds
+      - uses: actions/upload-artifact@v3
         with:
-          name: prebuild-${{ runner.os }}-${{ runner.arch }}
-          path: prebuilds
-          retention-days: 14
+          name: prebuild-${{ linux }}-${{ arm64 }}
+          path: ./prebuilds
 
   # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,10 +104,10 @@ jobs:
           mkdir -p prebuilds/linux-x64
           mkdir -p prebuilds/darwin-arm64
           find ${{ steps.download.outputs.download-path }}
-          mv ${{ steps.download.outputs.download-path}}prebuild-Linux-X64/linux-x64/* ./prebuilds/linux-x64/
-          mv ${{ steps.download.outputs.download-path}}prebuild-linux-arm64/linux-arm64/* ./prebuilds/linux-arm64/
-          mv ${{ steps.download.outputs.download-path}}prebuild-linux-arm64/linux-x64/* ./prebuilds/linux-x64/
-          mv ${{ steps.download.outputs.download-path}}prebuild-macOS-ARM64/darwin-arm64/* ./prebuilds/darwin-arm64/
+          mv ${{ steps.download.outputs.download-path}}/prebuild-Linux-X64/linux-x64/* ./prebuilds/linux-x64/
+          mv ${{ steps.download.outputs.download-path}}/prebuild-linux-arm64/linux-arm64/* ./prebuilds/linux-arm64/
+          mv ${{ steps.download.outputs.download-path}}/prebuild-linux-arm64/linux-x64/* ./prebuilds/linux-x64/
+          mv ${{ steps.download.outputs.download-path}}/prebuild-macOS-ARM64/darwin-arm64/* ./prebuilds/darwin-arm64/
           find ./prebuilds
       - name: npm install
         run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,47 +5,47 @@ on:
   workflow_dispatch:
 
 jobs:
-  # build:
-  #   # TODO: should we run the tests, or can we assume that a v* tag ought to
-  #   # get published?
-  #   name: build
-  #   strategy:
-  #     matrix:
-  #       node: [20]
-  #       os:
-  #         - name: darwin
-  #           architecture: arm64
-  #           host: macos-14
+  build:
+    # TODO: should we run the tests, or can we assume that a v* tag ought to
+    # get published?
+    name: build
+    strategy:
+      matrix:
+        node: [20]
+        os:
+          - name: darwin
+            architecture: arm64
+            host: macos-14
 
-  #         - name: linux
-  #           architecture: x86-64
-  #           host: ubuntu-20.04
-  #   env:
-  #     CC: clang
-  #     CXX: clang++
-  #     npm_config_clang: 1
-  #     GYP_DEFINES: use_obsolete_asm=true
-  #   runs-on: ${{ matrix.os.host }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: true
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 20
-  #         check-latest: true
-  #     - name: Prebuildify
-  #       run: |
-  #         [[ $(uname -o) == *Linux ]] && \
-  #           sudo apt-get update && \
-  #           sudo apt-get install -y software-properties-common git build-essential clang libssl-dev libkrb5-dev libc++-dev wget python3
-  #         npm ci
-  #         npx prebuildify --napi --strip --tag-libc -t "$(node --version | tr -d 'v')"
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: prebuild-${{ runner.os }}-${{ runner.arch }}
-  #         path: prebuilds
-  #         retention-days: 14
+          - name: linux
+            architecture: x86-64
+            host: ubuntu-20.04
+    env:
+      CC: clang
+      CXX: clang++
+      npm_config_clang: 1
+      GYP_DEFINES: use_obsolete_asm=true
+    runs-on: ${{ matrix.os.host }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          check-latest: true
+      - name: Prebuildify
+        run: |
+          [[ $(uname -o) == *Linux ]] && \
+            sudo apt-get update && \
+            sudo apt-get install -y software-properties-common git build-essential clang libssl-dev libkrb5-dev libc++-dev wget python3
+          npm ci
+          npx prebuildify --napi --strip --tag-libc -t "$(node --version | tr -d 'v')"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prebuild-${{ runner.os }}-${{ runner.arch }}
+          path: prebuilds
+          retention-days: 14
 
   cross-compile:
     name: "cross compile linux/arm"
@@ -78,9 +78,7 @@ jobs:
   # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
   publish:
     runs-on: ubuntu-latest
-    #TODO: make sure to re-add build in here too, commented out currently to speed up iteration
-    # needs: [build, cross-compile]
-    needs: [cross-compile]
+    needs: [build, cross-compile]
     permissions:
       id-token: write
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readme/nodegit",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@readme/nodegit",
-      "version": "1.1.0-alpha.6",
+      "version": "1.1.0-alpha.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readme/nodegit",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@readme/nodegit",
-      "version": "1.1.0-alpha.1",
+      "version": "1.1.0-alpha.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readme/nodegit",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@readme/nodegit",
-      "version": "1.0.0",
+      "version": "1.1.0-alpha.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readme/nodegit",
-  "version": "1.1.0-alpha.3",
+  "version": "1.1.0-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@readme/nodegit",
-      "version": "1.1.0-alpha.3",
+      "version": "1.1.0-alpha.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readme/nodegit",
-  "version": "1.1.0-alpha.2",
+  "version": "1.1.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@readme/nodegit",
-      "version": "1.1.0-alpha.2",
+      "version": "1.1.0-alpha.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readme/nodegit",
-  "version": "1.1.0-alpha.4",
+  "version": "1.1.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@readme/nodegit",
-      "version": "1.1.0-alpha.4",
+      "version": "1.1.0-alpha.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readme/nodegit",
-  "version": "1.1.0-alpha.5",
+  "version": "1.1.0-alpha.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@readme/nodegit",
-      "version": "1.1.0-alpha.5",
+      "version": "1.1.0-alpha.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readme/nodegit",
   "description": "Node.js libgit2 asynchronous native bindings",
-  "version": "1.1.0-alpha.2",
+  "version": "1.1.0-alpha.3",
   "homepage": "http://nodegit.org",
   "keywords": [
     "libgit2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readme/nodegit",
   "description": "Node.js libgit2 asynchronous native bindings",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.1",
   "homepage": "http://nodegit.org",
   "keywords": [
     "libgit2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readme/nodegit",
   "description": "Node.js libgit2 asynchronous native bindings",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "homepage": "http://nodegit.org",
   "keywords": [
     "libgit2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readme/nodegit",
   "description": "Node.js libgit2 asynchronous native bindings",
-  "version": "1.1.0-alpha.3",
+  "version": "1.1.0-alpha.4",
   "homepage": "http://nodegit.org",
   "keywords": [
     "libgit2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readme/nodegit",
   "description": "Node.js libgit2 asynchronous native bindings",
-  "version": "1.1.0-alpha.5",
+  "version": "1.1.0-alpha.6",
   "homepage": "http://nodegit.org",
   "keywords": [
     "libgit2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readme/nodegit",
   "description": "Node.js libgit2 asynchronous native bindings",
-  "version": "1.1.0-alpha.4",
+  "version": "1.1.0-alpha.5",
   "homepage": "http://nodegit.org",
   "keywords": [
     "libgit2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readme/nodegit",
   "description": "Node.js libgit2 asynchronous native bindings",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "homepage": "http://nodegit.org",
   "keywords": [
     "libgit2",

--- a/scripts/Dockerfile.alpine
+++ b/scripts/Dockerfile.alpine
@@ -1,0 +1,9 @@
+FROM node:20.11.1-alpine3.19
+
+RUN apk add build-base git krb5-dev libgit2-dev libssh-dev pkgconfig python3 tzdata
+
+ADD . /app
+WORKDIR /app
+
+RUN npm ci && \
+  npx prebuildify --napi --strip --tag-libc -t "$(node --version | tr -d 'v')"

--- a/scripts/Dockerfile.debian
+++ b/scripts/Dockerfile.debian
@@ -11,4 +11,4 @@ ADD . /app
 WORKDIR /app
 
 RUN npm ci && \
-  npx prebuildify --napi --strip -t "$(node --version | tr -d 'v')"
+  npx prebuildify --napi --strip --tag-libc -t "$(node --version | tr -d 'v')"

--- a/scripts/Dockerfile.ubuntu
+++ b/scripts/Dockerfile.ubuntu
@@ -1,0 +1,14 @@
+FROM node:20.11.1-bullseye
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL en_US.UTF-8
+ENV LANG ${LC_ALL}
+
+RUN apt-get update -y && \
+  apt-get install -y software-properties-common git build-essential clang libssl-dev libkrb5-dev libc++-dev wget python3
+
+ADD . /app
+WORKDIR /app
+
+RUN npm ci && \
+  npx prebuildify --napi --strip -t "$(node --version | tr -d 'v')"


### PR DESCRIPTION
Add three new supported build targets:

- linux-x64-musl
- linux-arm-libc
- linux-arm-musl

To support the alternate libcs, I've added `--tag-libc` to all prebuildify invocations. [docs here](https://www.npmjs.com/package/prebuildify#options)

TODO:

- [x] verify that the builds completed successfully and didn't overwrite each other
- [x] reënable the original build process, I've disabled it to try and speed up the release cycle, which is v v slow on gha