### PR TITLE
fix: correct publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,27 +57,32 @@ jobs:
           path: ./prebuilds
           retention-days: 14
 
+  # there are no alpine builders, so we do our musl builds in qemu, which is
+  # slow as a dumb running sonic. TODO: figure out how to cross-compile
+  # on the ubuntu runners; if we can it would save a ton of time
   cross-compile:
-    name: "cross compile linux/arm"
+    name: "cross compile ${{ matrix.platform }}-musl"
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+          - platform: linux/arm64
+            arch: arm64
     steps:
       - uses: actions/checkout@v5
       - uses: docker/setup-qemu-action@v3
-      - name: build linux musl x64
+      - name: build linux musl ${{ matrix.arch }}
         run: |
-          docker build --platform=linux/amd64 --tag nodegit-linux-musl-amd64 -f scripts/Dockerfile.alpine .
-          docker create --platform=linux/amd64 --name nodegit-linux-musl-amd64 nodegit-linux-musl-amd64
-          docker cp "nodegit-linux-musl-amd64:/app/prebuilds" .
-      - name: build linux musl arm
-        run: |
-          docker build --platform=linux/arm64 --tag nodegit-linux-musl-arm64 -f scripts/Dockerfile.alpine .
-          docker create --platform=linux/arm64 --name nodegit-linux-musl-arm64 nodegit-linux-musl-arm64
-          docker cp "nodegit-linux-musl-arm64:/app/prebuilds" .
+          docker build --platform=${{ matrix.platform }} --tag nodegit-linux-musl-${{ matrix.arch }} -f scripts/Dockerfile.alpine .
+          docker create --platform=${{ matrix.platform }} --name nodegit-linux-musl-${{ matrix.arch }} nodegit-linux-musl-${{ matrix.arch }}
+          docker cp "nodegit-linux-musl-${{ matrix.arch }}:/app/prebuilds" .
       - name: "list the generated files"
         run: find prebuilds
       - uses: actions/upload-artifact@v4
         with:
-          name: prebuild-linux-arm64
+          name: prebuild-linux-musl-${{ matrix.arch }}
           path: ./prebuilds
           retention-days: 14
 
@@ -110,8 +115,8 @@ jobs:
           mkdir -p prebuilds/darwin-arm64
           find ${{ steps.download.outputs.download-path }}
           mv ${{ steps.download.outputs.download-path}}/prebuild-Linux-X64/linux-x64/* ./prebuilds/linux-x64/
-          mv ${{ steps.download.outputs.download-path}}/prebuild-linux-arm64/linux-arm64/* ./prebuilds/linux-arm64/
-          mv ${{ steps.download.outputs.download-path}}/prebuild-linux-arm64/linux-x64/* ./prebuilds/linux-x64/
+          mv ${{ steps.download.outputs.download-path}}/prebuild-linux-musl-arm64/linux-arm64/* ./prebuilds/linux-arm64/
+          mv ${{ steps.download.outputs.download-path}}/prebuild-linux-musl-arm64/linux-x64/* ./prebuilds/linux-x64/
           mv ${{ steps.download.outputs.download-path}}/prebuild-macOS-ARM64/darwin-arm64/* ./prebuilds/darwin-arm64/
           mv ${{ steps.download.outputs.download-path}}/prebuild-macOS-X64/darwin-x64/* ./prebuilds/darwin-x64/
           find ./prebuilds

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
       CXX: clang++
       npm_config_clang: 1
       GYP_DEFINES: use_obsolete_asm=true
+      CXXFLAGS: -std=c++17
     runs-on: ${{ matrix.os.host }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,9 +106,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: true
+      # for the publish step, we need a version of npm that supports OIDC (>=
+      # 11.5.1, see https://docs.npmjs.com/trusted-publishers), so we build
+      # with node 24. Hopefully this is OK as the builds are still for node
+      # 20
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           check-latest: true
           registry-url: "https://registry.npmjs.org"
       - name: download built libraries

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
           retention-days: 14
 
   # musl build still needs QEMU since there are no native Alpine/musl runners
-  cross-compile-amd64:
+  cross-compile-musl-amd64:
     name: "cross compile linux/amd64-musl"
     runs-on: ubuntu-22.04
     steps:
@@ -77,7 +77,7 @@ jobs:
           path: ./prebuilds
           retention-days: 14
 
-  build-musl-arm:
+  cross-compile-musl-arm64:
     name: "build linux/arm64-musl"
     runs-on: ubuntu-22.04-arm
     steps:
@@ -98,7 +98,7 @@ jobs:
   # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
   publish:
     runs-on: ubuntu-latest
-    needs: [build, cross-compile-amd64, build-musl-arm]
+    needs: [build, cross-compile-musl-amd64, cross-compile-musl-arm64]
     permissions:
       id-token: write
       contents: read
@@ -124,12 +124,12 @@ jobs:
           mkdir -p prebuilds/darwin-arm64
           mkdir -p prebuilds/darwin-x64
           find ${{ steps.download.outputs.download-path }}
-          mv ${{ steps.download.outputs.download-path}}/prebuild-Linux-X64/linux-x64/* ./prebuilds/linux-x64/
-          mv ${{ steps.download.outputs.download-path}}/prebuild-Linux-ARM64/linux-arm64/* ./prebuilds/linux-arm64/
-          mv ${{ steps.download.outputs.download-path}}/prebuild-linux-musl-amd64/linux-x64/* ./prebuilds/linux-x64/
-          mv ${{ steps.download.outputs.download-path}}/prebuild-linux-musl-arm64/linux-arm64/* ./prebuilds/linux-arm64/
-          mv ${{ steps.download.outputs.download-path}}/prebuild-macOS-ARM64/darwin-arm64/* ./prebuilds/darwin-arm64/
-          mv ${{ steps.download.outputs.download-path}}/prebuild-macOS-X64/darwin-x64/* ./prebuilds/darwin-x64/
+          mv ${{ steps.download.outputs.download-path }}/prebuild-Linux-X64/linux-x64/* ./prebuilds/linux-x64/
+          mv ${{ steps.download.outputs.download-path }}/prebuild-Linux-ARM64/linux-arm64/* ./prebuilds/linux-arm64/
+          mv ${{ steps.download.outputs.download-path }}/prebuild-linux-musl-amd64/linux-x64/* ./prebuilds/linux-x64/
+          mv ${{ steps.download.outputs.download-path }}/prebuild-linux-musl-arm64/linux-arm64/* ./prebuilds/linux-arm64/
+          mv ${{ steps.download.outputs.download-path }}/prebuild-macOS-ARM64/darwin-arm64/* ./prebuilds/darwin-arm64/
+          mv ${{ steps.download.outputs.download-path }}/prebuild-macOS-X64/darwin-x64/* ./prebuilds/darwin-x64/
           find ./prebuilds
       - name: npm install
         run: npm ci
@@ -139,3 +139,5 @@ jobs:
       - name: publish
         run: |
           npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,11 @@ jobs:
         os:
           # macos-14 is arm64 (m1)
           - name: darwin
-            host: macos-13-arm64
+            host: macos-14
 
           # macos-13 is x86
           - name: mac-x64
-            host: macos-13-intel
+            host: macos-13
 
           # ubuntu-22.04 is x86. Still no arm linux runners yet
           # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,39 +57,48 @@ jobs:
           path: ./prebuilds
           retention-days: 14
 
-  # there are no alpine builders, so we do our musl builds in qemu, which is
-  # slow as a dumb running sonic. TODO: figure out how to cross-compile
-  # on the ubuntu runners; if we can it would save a ton of time
-  cross-compile:
-    name: "cross compile ${{ matrix.platform }}-musl"
+  # musl build still needs QEMU since there are no native Alpine/musl runners
+  cross-compile-amd64:
+    name: "cross compile linux/amd64-musl"
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            arch: amd64
-          - platform: linux/arm64
-            arch: arm64
     steps:
       - uses: actions/checkout@v5
       - uses: docker/setup-qemu-action@v3
-      - name: build linux musl ${{ matrix.arch }}
+      - name: build linux musl amd64
         run: |
-          docker build --platform=${{ matrix.platform }} --tag nodegit-linux-musl-${{ matrix.arch }} -f scripts/Dockerfile.alpine .
-          docker create --platform=${{ matrix.platform }} --name nodegit-linux-musl-${{ matrix.arch }} nodegit-linux-musl-${{ matrix.arch }}
-          docker cp "nodegit-linux-musl-${{ matrix.arch }}:/app/prebuilds" .
+          docker build --platform=linux/amd64 --tag nodegit-linux-musl-amd64 -f scripts/Dockerfile.alpine .
+          docker create --platform=linux/amd64 --name nodegit-linux-musl-amd64 nodegit-linux-musl-amd64
+          docker cp "nodegit-linux-musl-amd64:/app/prebuilds" .
       - name: "list the generated files"
         run: find prebuilds
       - uses: actions/upload-artifact@v4
         with:
-          name: prebuild-linux-musl-${{ matrix.arch }}
+          name: prebuild-linux-musl-amd64
+          path: ./prebuilds
+          retention-days: 14
+
+  build-musl-arm:
+    name: "build linux/arm64-musl"
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v5
+      - name: build linux musl arm64
+        run: |
+          docker build --platform=linux/arm64 --tag nodegit-linux-musl-arm64 -f scripts/Dockerfile.alpine .
+          docker create --platform=linux/arm64 --name nodegit-linux-musl-arm64 nodegit-linux-musl-arm64
+          docker cp "nodegit-linux-musl-arm64:/app/prebuilds" .
+      - name: "list the generated files"
+        run: find prebuilds
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prebuild-linux-musl-arm64
           path: ./prebuilds
           retention-days: 14
 
   # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
   publish:
     runs-on: ubuntu-latest
-    needs: [build, cross-compile]
+    needs: [build, cross-compile-amd64, build-musl-arm]
     permissions:
       id-token: write
       contents: read
@@ -113,10 +122,12 @@ jobs:
           mkdir -p prebuilds/linux-arm64
           mkdir -p prebuilds/linux-x64
           mkdir -p prebuilds/darwin-arm64
+          mkdir -p prebuilds/darwin-x64
           find ${{ steps.download.outputs.download-path }}
           mv ${{ steps.download.outputs.download-path}}/prebuild-Linux-X64/linux-x64/* ./prebuilds/linux-x64/
+          mv ${{ steps.download.outputs.download-path}}/prebuild-Linux-ARM64/linux-arm64/* ./prebuilds/linux-arm64/
+          mv ${{ steps.download.outputs.download-path}}/prebuild-linux-musl-amd64/linux-x64/* ./prebuilds/linux-x64/
           mv ${{ steps.download.outputs.download-path}}/prebuild-linux-musl-arm64/linux-arm64/* ./prebuilds/linux-arm64/
-          mv ${{ steps.download.outputs.download-path}}/prebuild-linux-musl-arm64/linux-x64/* ./prebuilds/linux-x64/
           mv ${{ steps.download.outputs.download-path}}/prebuild-macOS-ARM64/darwin-arm64/* ./prebuilds/darwin-arm64/
           mv ${{ steps.download.outputs.download-path}}/prebuild-macOS-X64/darwin-x64/* ./prebuilds/darwin-x64/
           find ./prebuilds

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,15 +106,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: true
-      # for the publish step, we need a version of npm that supports OIDC (>=
-      # 11.5.1, see https://docs.npmjs.com/trusted-publishers), so we build
-      # with node 24. Hopefully this is OK as the builds are still for node
-      # 20
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 20
           check-latest: true
           registry-url: "https://registry.npmjs.org"
+      # for the publish step, we need a version of npm that supports OIDC (>=
+      # 11.5.1, see https://docs.npmjs.com/trusted-publishers),
+      - name: upgrade npm for OIDC support
+        run: npm install -g npm@^11.5.1
       - name: download built libraries
         id: download
         uses: actions/download-artifact@v4

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     }
   ],
   "main": "lib/nodegit.js",
-  "repository": "github:readmeio/nodegit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/readmeio/nodegit.git"
+  },
   "directories": {
     "build": "./build",
     "lib": "./lib"

--- a/scripts/Dockerfile.alpine
+++ b/scripts/Dockerfile.alpine
@@ -2,6 +2,10 @@ FROM node:20.11.1-alpine3.19
 
 RUN apk add build-base git krb5-dev libgit2-dev libssh-dev pkgconfig python3 tzdata
 
+# Ensure C++17 is used explicitly for Node.js 20
+ENV CXXFLAGS="-std=c++17"
+ENV CFLAGS="-std=c17"
+
 ADD . /app
 WORKDIR /app
 

--- a/scripts/Dockerfile.alpine
+++ b/scripts/Dockerfile.alpine
@@ -2,9 +2,9 @@ FROM node:20.11.1-alpine3.19
 
 RUN apk add build-base git krb5-dev libgit2-dev libssh-dev pkgconfig python3 tzdata
 
-# Ensure C++17 is used explicitly for Node.js 20
-ENV CXXFLAGS="-std=c++17"
-ENV CFLAGS="-std=c17"
+# Ensure C++17 is used explicitly for Node.js 20 and define POSIX features
+ENV CXXFLAGS="-std=c++17 -D_GNU_SOURCE"
+ENV CFLAGS="-std=c17 -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L"
 
 ADD . /app
 WORKDIR /app

--- a/utils/defaultCxxStandard.js
+++ b/utils/defaultCxxStandard.js
@@ -13,7 +13,7 @@ if (targetSpecified) {
   }
 } else {
   const abiVersion = Number.parseInt(process.versions.modules) ?? 0;
-  // Node 18 === 108
+  // Node 18 === 108, Node 20 === 115
   if (abiVersion >= 131) {
     cxxStandard = '20';
   } else if (abiVersion >= 108) {


### PR DESCRIPTION
## 🧰 Changes

- use `macos13` for intel builds and `macos14` for arm builds. nodegit won't build on any more recent versions of macos
- add `-std=c++17` flags to make the compiler use C++17, which is required for node 20
    - to support node 22, we'll have to allow these to switch to `c++20`, but that's work for later
- upgrade npm version to support OIDC authentication
- parallelize cross-compile jobs and speed them up greatly by using the appropriate base platform
    - these used to take ~3 hours, and now take 15 minutes

closes #8

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
