### PR TITLE
chore: update mac runners, add JOBS to ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,12 @@ jobs:
       matrix:
         node: [20, 22]
         os:
-          # macos-14 is arm64 (m1)
+          # https://github.com/actions/runner-images#available-images
           - name: darwin
-            host: macos-14
+            host: macos-26 #arm64
 
-          # macos-13 is x86
           - name: mac-x64
-            host: macos-13
+            host: macos-15-intel
 
           # ubuntu-22.04 is x86. Still no arm linux runners yet
           # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
@@ -50,7 +49,6 @@ jobs:
             sudo apt-get install -y software-properties-common git build-essential clang libssl-dev libkrb5-dev libc++-dev wget python3 zlib1g-dev
 
           npm ci
-          # does the JOBS=2 speed things up? not sure
           JOBS=2 npx prebuildify --strip --napi=false --tag-libc -t "$(node --version | tr -d 'v')"
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,12 @@ jobs:
           - name: darwin
             host: macos-26 #arm64
 
+          # macos-15-intel is the last intel image and will go out of service
+          # in fall 2027
           - name: mac-x64
             host: macos-15-intel
 
-          # ubuntu-22.04 is x86. Still no arm linux runners yet
-          # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+          # ubuntu-22.04 is x86
           - name: linux
             host: ubuntu-22.04
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
           npm test
 
   mac-test:
-    name: "test node ${{ matrix.node-version }} on macOS"
+    name: "test node ${{ matrix.node-version }} on ${{ matrix.runner }}"
     env:
       CC: clang
       CXX: clang++

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add ~/.ssh_tests/id_rsa
 
-          npm install
+          JOBS=2 npm install
           npm test
 
   mac-test:
@@ -59,10 +59,11 @@ jobs:
       CXX: clang++
       npm_config_clang: 1
       GYP_DEFINES: use_obsolete_asm=true
-    runs-on: macos-26
     strategy:
       matrix:
         node-version: [20, 22]
+        runner: ["macos-26", "macos-15-intel"]
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -86,7 +87,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add ~/.ssh_tests/id_rsa
 
-          npm install
+          JOBS=2 npm install
           npm test
 
   linux-arm-test:
@@ -128,5 +129,5 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add ~/.ssh_tests/id_rsa
 
-          npm install
+          JOBS=2 npm install
           npm test

--- a/scripts/Dockerfile.alpine
+++ b/scripts/Dockerfile.alpine
@@ -6,6 +6,7 @@ RUN apk add build-base git krb5-dev libgit2-dev libssh-dev pkgconfig python3 tzd
 # Ensure C++17 is used explicitly for Node.js 20 and define POSIX features
 ENV CXXFLAGS="-std=c++17 -D_GNU_SOURCE"
 ENV CFLAGS="-std=c17 -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L"
+ENV JOBS="2"
 
 ADD . /app
 WORKDIR /app

--- a/scripts/Dockerfile.debian
+++ b/scripts/Dockerfile.debian
@@ -1,6 +1,7 @@
 FROM node:${NODE_VERSION}-bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV JOBS="2"
 ENV LC_ALL en_US.UTF-8
 ENV LANG ${LC_ALL}
 


### PR DESCRIPTION
## 🧰 Changes

- Add CI tests on macos-15-intel
- update test runners in the publish job
- add `JOBS=2` to all CI builds, which speed them up a bit
  - went from 8/9 minutes to 5/6
- remove a dead comment
